### PR TITLE
Explicit steps readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# Editor files
+*~

--- a/README.md
+++ b/README.md
@@ -23,8 +23,12 @@
 # Clone this repo, you should.
 $ git clone https://github.com/yoda-pa/yoda
 
-# create a virtualenv
-$ virtualenv venv
+# Change directory into the cloned repository
+$ cd yoda
+
+# create a virtualenv with python2
+# The path and the name of the executable may be different depending on your OS
+$ virtualenv -p /usr/bin/python2 venv
 
 # activate the virtualenv
 $ . venv/bin/activate


### PR DESCRIPTION
#### Short description of what this resolves:
Make it easier to know which version of python is required when installing yoda
#### Changes proposed in this pull request:
- Clearly stated that python2 is required. I modified the command to create the virtualenv to add the `-p` parameter. This parameter let you specify which version of python to use when creating the virtualenv.

- Added command to explicitly say to cange directory into the cloned repository after it has been cloned to remove ambiguity.

- Added entry in .gitignore for files createdby VIM.