### PR TITLE
add support for custom config location

### DIFF
--- a/config.py
+++ b/config.py
@@ -3,14 +3,34 @@ import os.path
 API_AI_TOKEN = 'caca38e8d99d4ea6bd9ffa9a8be15ff9'
 API_AI_SESSION_ID = 'dd60fde7-c6ab-4f38-9487-7300c42b4916'
 
-# gets home dir, works for all platforms
-USER_HOME_DIR = os.path.expanduser('~')
+# this is where yoda's config will be stored
+YODA_CONFIG_FILE_PATH = os.path.join(os.path.expanduser('~'), '.yodaconfig')
 
-config_file_paths = {
-    "CONFIG_FILE_PATH": USER_HOME_DIR + '/.yoda/.yodaconfig.yml',
-    "LOVE_CONFIG_FILE_PATH": USER_HOME_DIR + '/.yoda/love/.loveconfig.yml',
-    "MONEY_CONFIG_FILE_PATH": os.path.expanduser('~') + '/.yoda/money/.moneyconfig.yml',
-    "DIARY_CONFIG_FILE_PATH": os.path.expanduser('~') + '/.yoda/diary/.diaryconfig.yml',
-    "VOCABULARY_CONFIG_FILE_PATH": os.path.expanduser('~') + '/.yoda/vocabulary/.vocabularyconfig.yml',
-    "FLASHCARDS_CONFIG_FILE_PATH": os.path.expanduser('~') + '/.yoda/flashcards/.flashcardsconfig.yml'
-}
+DEFAULT_CONFIG_PATH = os.path.join(os.path.expanduser('~'), '.yoda')
+
+
+def update_config_path(new_path):
+    if len(new_path) == 0:
+        new_path = DEFAULT_CONFIG_PATH
+    with open(YODA_CONFIG_FILE_PATH, 'w') as config_file:
+        config_file.write(new_path)
+    return new_path
+
+
+def get_config_file_paths():
+    try:
+        with open(YODA_CONFIG_FILE_PATH) as config_file:
+            config_path_prefix = config_file.read().strip()
+    except IOError:
+        config_path_prefix = DEFAULT_CONFIG_PATH
+
+    return {
+        "USER_CONFIG_FILE_PATH":       os.path.join(config_path_prefix, '.userconfig.yml'),
+        "LOVE_CONFIG_FILE_PATH":       os.path.join(config_path_prefix, 'love/.loveconfig.yml'),
+        "MONEY_CONFIG_FILE_PATH":      os.path.join(config_path_prefix, 'money/.moneyconfig.yml'),
+        "DIARY_CONFIG_FILE_PATH":      os.path.join(config_path_prefix, 'diary/.diaryconfig.yml'),
+        "VOCABULARY_CONFIG_FILE_PATH": os.path.join(config_path_prefix, 'vocabulary/.vocabularyconfig.yml'),
+        "FLASHCARDS_CONFIG_FILE_PATH": os.path.join(config_path_prefix, 'flashcards/.flashcardsconfig.yml')
+    }
+
+

--- a/config.py
+++ b/config.py
@@ -10,6 +10,10 @@ DEFAULT_CONFIG_PATH = os.path.join(os.path.expanduser('~'), '.yoda')
 
 
 def update_config_path(new_path):
+    '''Updates the path where the config files are stored.
+    This is done by changing the contents of YODA_CONFIG_FILE_PATH with new_path
+    of user's config.
+    '''
     if len(new_path) == 0:
         new_path = DEFAULT_CONFIG_PATH
     with open(YODA_CONFIG_FILE_PATH, 'w') as config_file:
@@ -18,6 +22,9 @@ def update_config_path(new_path):
 
 
 def get_config_file_paths():
+    '''Get the absolute config file paths of user
+    config_path_prefix is where the config files are stored.
+    '''
     try:
         with open(YODA_CONFIG_FILE_PATH) as config_file:
             config_path_prefix = config_file.read().strip()

--- a/modules/diary.py
+++ b/modules/diary.py
@@ -1,6 +1,6 @@
 import click
 import chalk
-from config import config_file_paths
+from config import get_config_file_paths
 import os.path
 from os import listdir
 import time
@@ -11,7 +11,7 @@ import datetime
 
 
 # config file path
-DIARY_CONFIG_FILE_PATH = config_file_paths['DIARY_CONFIG_FILE_PATH']
+DIARY_CONFIG_FILE_PATH = get_config_file_paths()['DIARY_CONFIG_FILE_PATH']
 DIARY_CONFIG_FOLDER_PATH = get_folder_path_from_file_path(
     DIARY_CONFIG_FILE_PATH)
 

--- a/modules/git.py
+++ b/modules/git.py
@@ -5,7 +5,7 @@ import github
 from dulwich import porcelain
 from os import mkdir
 
-from config import config_file_paths
+from config import get_config_file_paths
 from util import *
 
 
@@ -15,9 +15,9 @@ def process(input):
     gh = github.Github(gh_username, gh_password)
     click.echo(chalk.blue('you are in git module'))
     click.echo('input = %s' % input)
-    CONFIG_FILE_PATH = config_file_paths['CONFIG_FILE_PATH']
-    CONFIG_FOLDER_PATH = get_folder_path_from_file_path(CONFIG_FILE_PATH)
-    repo = porcelain.init(CONFIG_FOLDER_PATH)
+    USER_CONFIG_FILE_PATH = get_config_file_paths()['USER_CONFIG_FILE_PATH']
+    USER_CONFIG_FOLDER_PATH = get_folder_path_from_file_path(USER_CONFIG_FILE_PATH)
+    repo = porcelain.init(USER_CONFIG_FOLDER_PATH)
     porcelain.add(repo)
     porcelain.commit(repo, "A sample commit")
     porcelain.remote_add(repo, ".yoda", "https://github.com/manparvesh/.yoda")

--- a/modules/learn.py
+++ b/modules/learn.py
@@ -2,7 +2,7 @@ import click
 import chalk
 import random
 from util import *
-from config import config_file_paths
+from config import get_config_file_paths
 import time
 import datetime
 import requests
@@ -21,7 +21,7 @@ def learn():
 
 
 # config file path
-VOCABULARY_CONFIG_FILE_PATH = config_file_paths["VOCABULARY_CONFIG_FILE_PATH"]
+VOCABULARY_CONFIG_FILE_PATH = get_config_file_paths()["VOCABULARY_CONFIG_FILE_PATH"]
 VOCABULARY_CONFIG_FOLDER_PATH = get_folder_path_from_file_path(
     VOCABULARY_CONFIG_FILE_PATH)
 
@@ -128,7 +128,7 @@ def vocabulary(input):
 
 # ----------------------- flashcards code -----------------------#
 # config file path
-FLASHCARDS_CONFIG_FILE_PATH = config_file_paths["FLASHCARDS_CONFIG_FILE_PATH"]
+FLASHCARDS_CONFIG_FILE_PATH = get_config_file_paths()["FLASHCARDS_CONFIG_FILE_PATH"]
 FLASHCARDS_CONFIG_FOLDER_PATH = get_folder_path_from_file_path(
     FLASHCARDS_CONFIG_FILE_PATH)
 

--- a/modules/love.py
+++ b/modules/love.py
@@ -1,10 +1,10 @@
 import click
 import chalk
-from config import config_file_paths
+from config import get_config_file_paths
 from util import *
 
 # config file path
-LOVE_CONFIG_FILE_PATH = config_file_paths["LOVE_CONFIG_FILE_PATH"]
+LOVE_CONFIG_FILE_PATH = get_config_file_paths()["LOVE_CONFIG_FILE_PATH"]
 LOVE_CONFIG_FOLDER_PATH = get_folder_path_from_file_path(LOVE_CONFIG_FILE_PATH)
 LOVE_NOTES_FILE_PATH = LOVE_CONFIG_FOLDER_PATH + '/notes.yaml'
 

--- a/modules/money.py
+++ b/modules/money.py
@@ -9,7 +9,7 @@ import time
 import datetime
 import shlex
 
-from config import config_file_paths
+from config import get_config_file_paths
 from util import *
 
 CLIENT_ACCESS_TOKEN = os.environ.get('API_AI_TOKEN', config.API_AI_TOKEN)
@@ -19,7 +19,7 @@ request.session_id = os.environ.get(
     'API_AI_SESSION_ID', config.API_AI_SESSION_ID)
 
 # config file path
-MONEY_CONFIG_FILE_PATH = config_file_paths['MONEY_CONFIG_FILE_PATH']
+MONEY_CONFIG_FILE_PATH = get_config_file_paths()['MONEY_CONFIG_FILE_PATH']
 MONEY_CONFIG_FOLDER_PATH = get_folder_path_from_file_path(
     MONEY_CONFIG_FILE_PATH)
 

--- a/modules/setup.py
+++ b/modules/setup.py
@@ -3,13 +3,15 @@ import chalk
 import getpass
 import lepl.apps.rfc3696
 import yaml
+import errno
 import os.path
 from Crypto.Cipher import AES
 import string
 import random
-from config import config_file_paths
+from config import get_config_file_paths
+from config import update_config_path
 
-CONFIG_FILE_PATH = config_file_paths['CONFIG_FILE_PATH']
+CONFIG_FILE_PATH = get_config_file_paths()['USER_CONFIG_FILE_PATH']
 
 # used to generate key and IV456 for Crypto
 
@@ -74,6 +76,19 @@ def new():
 
     encrypted_gh_password = encrypt_password(
         cipher_key, cipher_IV456, gh_password)
+
+    chalk.blue('Where shall your config be stored? (Default: ~/.yoda/)')
+    # because os.path.isdir doesn't expand ~
+    config_path = os.path.expanduser(raw_input().strip())
+    while not os.path.isdir(config_path):
+        if len(config_path) == 0:
+            break
+        chalk.red('Path doesn\'t exist, yoda!')
+        chalk.blue('Where shall your config be stored? (Default: ~/.yoda/)')
+        config_path = os.path.expanduser(raw_input().strip())
+
+    update_config_path(config_path)
+    CONFIG_FILE_PATH = get_config_file_paths()['USER_CONFIG_FILE_PATH']
 
     setup_data = dict(
         name=name,


### PR DESCRIPTION
#### Short description of what this resolves:
Adds support for custom config location.

#### Changes proposed in this pull request:

- Yoda will have a global config store at `~/.yodaconfig` (plain text containing the path of actual location where files are stored) (Defaults to `~/.yoda/`, managed via `modules/setup.py`)
- `config_file_path` in `config.py` has change in nature and is thus accessed via `get_config_file_paths` method.
- User's config file, previously called `CONFIG_FILE_PATH` is now called `USER_CONFIG_FILE_PATH` and the name changes from `.yodaconfig.yml` to `.userconfig.yml`.
- Setup process in `modules/setup.py` has been modified accordingly, providing default path as well.
- All affected modules have been modified accordingly.

**Fixes**: #3 

@manparvesh  Please have a look over this.