### PR TITLE
#39 bugfix: chat has better response in offline mode

### DIFF
--- a/modules/chat.py
+++ b/modules/chat.py
@@ -4,6 +4,8 @@ import config
 import os
 import apiai
 import json
+import socket
+import sys
 
 CLIENT_ACCESS_TOKEN = os.environ.get('API_AI_TOKEN', config.API_AI_TOKEN)
 ai = apiai.ApiAI(CLIENT_ACCESS_TOKEN)
@@ -14,7 +16,13 @@ request.session_id = os.environ.get(
 
 def process(input_string):
     request.query = input_string
-    response = request.getresponse().read()
+    try:
+        response = request.getresponse().read()
+    except socket.gaierror:
+        # if the user is not connected to internet dont give a response 
+        click.echo('Yoda cannot sense the internet right now!')
+        sys.exit(1)
+
     output = json.loads(response)
     answer = output["result"]["fulfillment"]["speech"]
     chalk.blue('Yoda speaks:')


### PR DESCRIPTION
Moved the request into a try/catch block and listen for the corresponding error. 

If the error is caught, that means the user is offline. So give a simple friendly reminder that the user is offline and exit the program.