### PR TITLE
Add printed response when no word in define is found

### DIFF
--- a/modules/learn.py
+++ b/modules/learn.py
@@ -543,5 +543,6 @@ def define(word):
             chalk.red('Sorry, no definitions were found for this word')
     except KeyError:
         chalk.red('Sorry, no definitions were found for this word')
+        print('Sorry, no definitions were found for this word')
 
 # ----------------------- / define code -----------------------#

--- a/resources/vocab-words.txt
+++ b/resources/vocab-words.txt
@@ -676,3 +676,10 @@ parlous - full of danger or uncertainty; precarious
 pilloried - attack or ridicule publicly; pillory is a wooden shackle
 expatiate - speak or write at length or in detail
 man - someone who serves in the armed forces; a member of a military force
+person - a human being
+bowie - United States pioneer and hero of the Texas revolt against Mexico; he shared command of the garrison that resisted the Mexican attack on the Alamo where he died (1796-1836)
+tesla - United States electrical engineer and inventor (born in Croatia but of Serbian descent) who discovered the principles of alternating currents and developed the first alternating-current induction motor and the Tesla coil and several forms of oscillators (1856-1943)
+help - a person who contributes to the fulfillment of a need or furtherance of an effort or purpose
+hello - an expression of greeting
+who - a United Nations agency to coordinate international health activities and to help governments improve health services
+woman - a human female employed to do housework


### PR DESCRIPTION
I noticed when using define and no word is found a blank message is returned so I decided to add a simple "Sorry, no definitions were found for this word", as a printed message