### PR TITLE
Define raw_input() for Python 3

### DIFF
--- a/modules/setup.py
+++ b/modules/setup.py
@@ -15,6 +15,11 @@ from config import update_config_path
 
 CONFIG_FILE_PATH = get_config_file_paths()['USER_CONFIG_FILE_PATH']
 
+try:
+    raw_input          # Python 2
+except NameError:
+    raw_input = input  # Python 3
+
 
 def cypher_pass_generator(size=16, chars=string.ascii_uppercase + string.digits):
     """

--- a/modules/util.py
+++ b/modules/util.py
@@ -6,6 +6,11 @@ import chalk
 import click
 import yaml
 
+try:
+    raw_input          # Python 2
+except NameError:
+    raw_input = input  # Python 3
+
 
 def create_folder(folder_path):
     """


### PR DESCRIPTION
#### Short description of what this resolves:

 __raw_input()__ was removed in Python 3 in favor of  __input()__.

#### Changes proposed in this pull request:

-
-
-

**Fixes**: Python 3 compatibly 