### PR TITLE
Fixed issue #96 - crash on no description

### DIFF
--- a/modules/dev.py
+++ b/modules/dev.py
@@ -131,14 +131,21 @@ def hackernews():
     response = requests.get(_url)
     result = response.json()
     if result['status'] == 'ok':
-        for index in range(result['totalResults']):
-            click.echo('News-- ' + str(index + 1) + '/' + str(result['totalResults']) + '\n')
-            click.echo('Title--  ' + result['articles'][index]['title'])
-            click.echo('Description-- ' + result['articles'][index]['description'])
-            click.echo('url-- ' + str(result['articles'][index]['url']) + '\n')
+        for index, item in enumerate(result['articles']):
+            counter = '{}/{} \n'.format((index + 1), len(result['articles']))
+
+            title = item['title'] or 'No title'
+            description = item['description'] or 'No description'
+            url = item['url'] or 'No url'
+
+            click.echo('News-- ' + counter)
+            click.echo('Title--  ' + title)
+            click.echo('Description-- ' + description)
+            click.echo('url-- ' + url)
+            click.echo()
             click.echo('Continue? [press-"y"] ')
             c = click.getchar()
-            click.echo()
+            click.echo()  # newline after news item
             if c != 'y':
                 break
     else:


### PR DESCRIPTION
#### Short description of what this resolves:
The code for `yoda hackernews` is also more readable and doesn't crash when the description is None
I think I messed up the last pull request, closed it on accident.

#### Changes proposed in this pull request:

- removed `range(result['totalResults'))`, since the counter given by the API from the url wasn't the amount of news item returned by the API, which is confusing for the user. Maybe an issue in the API, but this solution is now always correct with the given amount of news articles.
- If the `title`, `description` or `url` is None, the click echoes _No description_ instead of crashing.
- makes the code a bit more readable.

**Fixes**: #96