### PR TITLE
Close file in the except block

### DIFF
--- a/modules/alias.py
+++ b/modules/alias.py
@@ -19,7 +19,8 @@ class Alias(click.Group):
                 for i in range(1, len(lines), 2):
                     Alias._aliases[lines[i].strip('\n')] = lines[i - 1].strip('\n').split()
         except:
-            open(ALIAS_CONFIG_FOLDER_PATH + '/alias.txt', 'w')
+            fo = open(ALIAS_CONFIG_FOLDER_PATH + '/alias.txt', 'w')
+            fo.close()
         super(Alias, self).__init__(*args, **kwargs)
 
     # this implementation does not work with current version of click


### PR DESCRIPTION
#### Short description of what this resolves: 
Closes file in the except block 

#### Changes proposed in this pull request: 
There shouldn't be a problem with the file closing without assigning it a variable because then it'd be discarded immediately. If that is the problem, then I just assigned the 'fo' variable for the file opening and then closed the file, so that we're sure it closes.

**Fixes**: #107 