### PR TITLE
Money api fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ requests==2.18.4
 urllib3==1.22
 future==0.16.0
 pychalk==2.0.0
-forex-python==0.3.3
+forex-python==1.0.0
 lepl==5.1.3
 nose==1.3.7
 pyyaml==3.12


### PR DESCRIPTION
#### Short description of what this resolves:
Solves TRAVIS CI build fail and yoda money broken  #command

#### Changes proposed in this pull request:

- Update requirements.txt to install forex-python 1.0.0 as stated in forex-python docs
-
-

**Fixes**: #113 