### PR TITLE
Update chat.py

### DIFF
--- a/modules/chat.py
+++ b/modules/chat.py
@@ -41,7 +41,7 @@ def process(input_string):
             'key': ""
         }
         hdr = {'User-Agent': "Magic Browser"}
-        full_url = QUOTE_API_URL + '?' + urllib.urlencode(send_data)
+        full_url = QUOTE_API_URL + '?' + urllib.parse.urlencode(send_data)
         response = urlopen(Request(full_url, headers=hdr))
         response = response.read()
         output = json.loads(response)


### PR DESCRIPTION
urllib.urlencode becomes urllib.parse.encode in Python 3. I think this will fix the AttributeError happening on line 44.

#### Short description of what this resolves:
Attribute Error happening on line 44 of chat.py
#### Changes proposed in this pull request:
Changing urllib.urlencode to urllib.parse.encode for Python 3 compatibility. 
-
-
-

**Fixes**: #