### PR TITLE
Document IP lookup feature / Fix iplookup None bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
   <h1>yoda</h1>
 
-<a href="https://travis-ci.org/yoda-pa/yoda"><img src="https://img.shields.io/travis-ci/yoda-pa/yoda.svg?style=flat-square" alt="Build status"></a> 
-  <a href="https://sonarcloud.io/dashboard?id=yoda"><img src="https://sonarcloud.io/api/project_badges/measure?project=yoda&metric=alert_status&template=FLAT" alt="SonarCloud Quality Status"></a> 
-  <a href="https://manparvesh.mit-license.org/"><img src="https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square" alt="License"></a> 
+<a href="https://travis-ci.org/yoda-pa/yoda"><img src="https://img.shields.io/travis-ci/yoda-pa/yoda.svg?style=flat-square" alt="Build status"></a>
+  <a href="https://sonarcloud.io/dashboard?id=yoda"><img src="https://sonarcloud.io/api/project_badges/measure?project=yoda&metric=alert_status&template=FLAT" alt="SonarCloud Quality Status"></a>
+  <a href="https://manparvesh.mit-license.org/"><img src="https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square" alt="License"></a>
   <a href="https://github.com/yoda-pa/yoda"><img src="https://img.shields.io/badge/version-0.3.0-blue.svg?style=flat-square" alt="Project status"></a>
 
   <p>Wise and powerful personal assistant, available in your nearest terminal</p><br>
@@ -162,6 +162,15 @@ $ yoda ideas remove --task <task_name> --inside <project_name>
 $ yoda ideas remove --project <project_name>
 ```
 
+#### IP lookup
+
+Get the geographical location of an IP address.
+
+```
+$ yoda iplookup 23.20.227.213
+$ Virginia, United States
+```
+
 #### learn
 
 This command group contains commands that, helpful in learning new things, will be.  Yeesssssss.
@@ -207,24 +216,24 @@ This command group contains commands to alias cumbersome commands.
   ```
   # before: shortening a url
   $ yoda url shorten google.com
-  
+
   # alias shorten to be s
   $ yoda alias new "shorten" "s"
-  
+
   # can now use s in place of shorten
   $ yoda url s google.com
-  
+
   # or alias the whole command as us
   $ yoda alias new "url shorten" "us"
   $ yoda us google.com
-  
+
   # show your current aliases
   $ yoda alias show
-  
+
   # delete aliases
   $ yoda alias delete "us"
   $ yoda alias delete "s"
-  
+
   ```
 
 #### feedback
@@ -250,12 +259,13 @@ To create an issue in the github repository simple thing that shows a link.  Yee
 - [chardet](https://github.com/chardet/chardet): universal character encoding detector
 - [Codecov](https://codecov.io/): code coverage dashboard
 - [coverage](https://pypi.org/project/coverage/): For code coverage testing
-- [NumPy](http://www.numpy.org/): For scientific computation 
+- [NumPy](http://www.numpy.org/): For scientific computation
 - [requests](http://docs.python-requests.org/en/latest/): For HTTP requests
-- [nose](https://github.com/nose-devs/nose): For unit testing 
-- [urllib3](https://github.com/urllib3/urllib3): HTTP client 
+- [nose](https://github.com/nose-devs/nose): For unit testing
+- [urllib3](https://github.com/urllib3/urllib3): HTTP client
 - [Certifi](https://github.com/certifi/python-certifi): Python SSL Certificates
-- [idna](https://github.com/kjd/idna): For the domain name 
+- [idna](https://github.com/kjd/idna): For the domain name
+- [GeoIP2-database](https://www.maxmind.com/en/geoip2-city): For geographical IP lookups
 - [future](https://pypi.org/project/future/): the layer of compatability for Python 2/3
 - [Google URL Shortener](https://developers.google.com/url-shortener/): URL shortener
 - [News API](https://newsapi.org/): Used to get the top headlines from Hacker News

--- a/modules/dev.py
+++ b/modules/dev.py
@@ -214,7 +214,14 @@ def portscan():
 @click.pass_context
 @click.argument('ip_address', nargs=1, required=False, callback=alias_checker)
 def iplookup(ctx, ip_address):
+    """
+    Find the geographical location of a given IP address.
+    """
+    # import pdb; pdb.set_trace()
     ip_address = get_arguments(ctx, 1)
+    if not ip_address:
+        return click.echo('Please supply an IP address as follows: $ yoda iplookup <ip_address>')
+
     _ip_address = str(ip_address)
 
     import geoip2.database

--- a/modules/learn.py
+++ b/modules/learn.py
@@ -23,7 +23,7 @@ from .util import *
 @click.group()
 def learn():
     """
-        The learn module2
+        The learn module
     """
 
 

--- a/modules/learn.py
+++ b/modules/learn.py
@@ -23,7 +23,7 @@ from .util import *
 @click.group()
 def learn():
     """
-        The learn module
+        The learn module2
     """
 
 


### PR DESCRIPTION
#### Short description of what this resolves:

Fixed `yoda iplookup` crashing when no argument was supplied.
Added README.md documentation as well as a link to the database used.
