### PR TITLE
Fix wrong indications

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -26,8 +26,8 @@ If you are interested in contributing by writing code, you can do so by implemen
 # Fork, then clone the repo
 $ git clone git@github.com:<your-username>/yoda.git
 
-# create a virtualenv
-$ virtualenv venv  
+# create a virtualenv using python 2
+$ virtualenv -p /usr/bin/python2 venv
 
 # activate the virtualenv
 $ . venv/bin/activate

--- a/yoda.py
+++ b/yoda.py
@@ -253,7 +253,7 @@ from modules import weather
 def weather(ctx, input):
     """
     Get weather\n
-    To use, type: yoda chat <location>
+    To use, type: yoda weather <location>
     """
     input = util.get_arguments(ctx, -1)
     if input:


### PR DESCRIPTION
#### Short description of what this resolves:
Wrong indications in the CLI help and contribution markdown page

#### Changes proposed in this pull request:

- Fix the `yoda weather --help` command by displaying the correct help message
- Fix the `CONTRIBUTING.md` by specifying that the virtual env should be created using `python 2`, as it is already said in the `README.md`

**Fixes**: #