### PR TITLE
Fix Money sub command error

### DIFF
--- a/modules/money.py
+++ b/modules/money.py
@@ -94,7 +94,7 @@ def expense():
         request.query = input()
         click.echo('output: ')
         response = request.getresponse().read()
-        output = json.loads(response)
+        output = json.loads(response.decode('utf8').replace('\n', ''))
         # click.echo(output)
         currency_name = output['result']['parameters']['currency-name']
         item = output['result']['parameters']['any'] if len(output['result']['parameters']['any'].split(


### PR DESCRIPTION
`c` was coming in as a full string instead of just the sub command so if I ran
```
money exp 'bought 20'
```

`c` was equal to `exp bought 20` so I just split the string by spaces and use the first one instead. This should fix the broken test as it was complaining about the `exp` sub command not existing