### PR TITLE
adding mock to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ lxml==3.5.0
 pandas==0.23.4
 fuzzywuzzy==0.17.0
 python-levenshtein==0.12.0
+mock==2.0.0


### PR DESCRIPTION
Merge of PR #225  introduced some `import mock` but the mock library wasn't added to the requirements file.