### PR TITLE
Tests and minor improvements to ciphers module

### DIFF
--- a/modules/ciphers/atbash.py
+++ b/modules/ciphers/atbash.py
@@ -1,4 +1,5 @@
 import string
+import sys
 
 import click
 
@@ -28,7 +29,7 @@ class AtbashCipher:
         for char in message:
             if char not in self.alphabet and char != " ":
                 click.echo("Atbash only supports ASCII characters.")
-                return
+                sys.exit(1)
 
             encrypted_message += self.key[char]
         return encrypted_message

--- a/modules/ciphers/caesar.py
+++ b/modules/ciphers/caesar.py
@@ -1,6 +1,7 @@
 import collections
 import itertools
 import string
+import sys
 
 import click
 
@@ -20,7 +21,7 @@ class CaesarCipher:
         for char in message:
             if char not in string.ascii_uppercase and char != " ":
                 click.echo("The Caesar Cipher only supports ASCII characters")
-                return
+                sys.exit(1)
 
             if char == " ":
                 encrypted_text += " "
@@ -41,7 +42,7 @@ class CaesarCipher:
         for char in message:
             if char not in string.ascii_uppercase and char != " ":
                 click.echo("The Caesar Cipher only supports ASCII characters")
-                return
+                sys.exit(1)
 
             if char == " ":
                 decrypted_text += " "

--- a/modules/ciphers/rot13.py
+++ b/modules/ciphers/rot13.py
@@ -1,6 +1,7 @@
 import collections
 import itertools
 import string
+import sys
 
 import click
 
@@ -31,7 +32,7 @@ class ROT13Cipher:
         for char in message:
             if char not in string.ascii_uppercase and char != " ":
                 click.echo("The ROT13 Cipher only supports ASCII characters")
-                return
+                sys.exit(1)
 
             if char == " ":
                 encrypted_text += " "
@@ -49,7 +50,7 @@ class ROT13Cipher:
         for char in message:
             if char not in string.ascii_uppercase and char != " ":
                 click.echo("The ROT13 Cipher only supports ASCII characters")
-                return
+                sys.exit(1)
 
             if char == " ":
                 decrypted_text += " "

--- a/modules/dev.py
+++ b/modules/dev.py
@@ -730,7 +730,7 @@ def ciphers(ctx, mode):
     mode = get_arguments(ctx, 1)
     if mode is None:
         click.echo("No mode was passed.(choose encrypt or decrypt")
-        return
+        sys.exit(1)
 
     _mode = str(mode).lower()
 
@@ -747,7 +747,7 @@ def ciphers(ctx, mode):
     cipher_choice = int(click.prompt("Choose a cipher"))
     if cipher_choice > len(cipher_dict) - 1 or cipher_choice < 0:
         click.echo("Invalid cipher number was chosen.")
-        return
+        sys.exit(1)
 
     cipher = cipher_dict[list(cipher_dict.keys())[cipher_choice]]()
 
@@ -758,7 +758,8 @@ def ciphers(ctx, mode):
         cipher_text = click.prompt("The text you want to decrypt")
         return click.echo(cipher.decrypt(cipher_text))
     else:
-        return click.echo("Invalid mode passed.")
+        click.echo("Invalid mode passed.")
+        sys.exit(1)
 
 
 @dev.command()

--- a/tests/ciphers/test_atbash.py
+++ b/tests/ciphers/test_atbash.py
@@ -1,0 +1,45 @@
+# coding=utf-8
+import unittest
+from click.testing import CliRunner
+
+import yoda
+
+
+class TestAtbash(unittest.TestCase):
+    """
+        Test for the following commands:
+
+        | Module: ciphers
+        | command: ciphers
+        | args: encrypt
+        | input: 2 <text>
+    """
+
+    def __init__(self, methodName="runTest"):
+        super(TestAtbash, self).__init__()
+        self.runner = CliRunner()
+
+    def runTest(self):
+        # testing for invalid text input for Atbash encryption
+        result = self.runner.invoke(yoda.cli, ["ciphers", "encrypt"],
+                                    input="2\n$#$#")
+        self.assertNotEquals(result.exit_code, 0)
+
+        # testing for invalid text input for Atbash decryption
+        result = self.runner.invoke(yoda.cli, ["ciphers", "decrypt"],
+                                    input="2\n12345")
+        self.assertNotEquals(result.exit_code, 0)
+
+        # testing for working Atbash encryption
+        result = self.runner.invoke(yoda.cli, ["ciphers", "encrypt"],
+                                    input="2\nsample")
+        self.assertEqual(result.exit_code, 0)
+
+        # testing for working Atbash decryption
+        result = self.runner.invoke(yoda.cli, ["ciphers", "decrypt"],
+                                    input="2\nsample")
+        self.assertEqual(result.exit_code, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ciphers/test_atbash.py
+++ b/tests/ciphers/test_atbash.py
@@ -23,12 +23,12 @@ class TestAtbash(unittest.TestCase):
         # testing for invalid text input for Atbash encryption
         result = self.runner.invoke(yoda.cli, ["ciphers", "encrypt"],
                                     input="2\n$#$#")
-        self.assertNotEquals(result.exit_code, 0)
+        self.assertNotEqual(result.exit_code, 0)
 
         # testing for invalid text input for Atbash decryption
         result = self.runner.invoke(yoda.cli, ["ciphers", "decrypt"],
                                     input="2\n12345")
-        self.assertNotEquals(result.exit_code, 0)
+        self.assertNotEqual(result.exit_code, 0)
 
         # testing for working Atbash encryption
         result = self.runner.invoke(yoda.cli, ["ciphers", "encrypt"],

--- a/tests/ciphers/test_atbash.py
+++ b/tests/ciphers/test_atbash.py
@@ -12,7 +12,7 @@ class TestAtbash(unittest.TestCase):
         | Module: ciphers
         | command: ciphers
         | args: encrypt
-        | input: 2 <text>
+        | input: 0 <text>
     """
 
     def __init__(self, methodName="runTest"):
@@ -22,22 +22,22 @@ class TestAtbash(unittest.TestCase):
     def runTest(self):
         # testing for invalid text input for Atbash encryption
         result = self.runner.invoke(yoda.cli, ["ciphers", "encrypt"],
-                                    input="2\n$#$#")
+                                    input="0\n$#$#")
         self.assertNotEqual(result.exit_code, 0)
 
         # testing for invalid text input for Atbash decryption
         result = self.runner.invoke(yoda.cli, ["ciphers", "decrypt"],
-                                    input="2\n12345")
+                                    input="0\n12345")
         self.assertNotEqual(result.exit_code, 0)
 
         # testing for working Atbash encryption
         result = self.runner.invoke(yoda.cli, ["ciphers", "encrypt"],
-                                    input="2\nsample")
+                                    input="0\nsample")
         self.assertEqual(result.exit_code, 0)
 
         # testing for working Atbash decryption
         result = self.runner.invoke(yoda.cli, ["ciphers", "decrypt"],
-                                    input="2\nsample")
+                                    input="0\nsample")
         self.assertEqual(result.exit_code, 0)
 
 

--- a/tests/ciphers/test_ceaser.py
+++ b/tests/ciphers/test_ceaser.py
@@ -1,0 +1,55 @@
+# coding=utf-8
+import unittest
+from click.testing import CliRunner
+
+import yoda
+
+
+class TestCeaser(unittest.TestCase):
+    """
+        Test for the following commands:
+
+        | Module: ciphers
+        | command: ciphers
+        | args: encrypt
+        | input: 0 <text> <shift>
+    """
+
+    def __init__(self, methodName="runTest"):
+        super(TestCeaser, self).__init__()
+        self.runner = CliRunner()
+
+    def runTest(self):
+        # testing for invalid shift input for ceaser encryption
+        result = self.runner.invoke(yoda.cli, ["ciphers", "encrypt"],
+                                    input="0\nsample\na")
+        self.assertNotEquals(result.exit_code, 0)
+
+        # testing for invalid shift input for ceaser decryption
+        result = self.runner.invoke(yoda.cli, ["ciphers", "decrypt"],
+                                    input="0\nsample\na")
+        self.assertNotEquals(result.exit_code, 0)
+
+        # testing for invalid text input for ceaser encryption
+        result = self.runner.invoke(yoda.cli, ["ciphers", "encrypt"],
+                                    input="0\n$#$#\n3")
+        self.assertNotEquals(result.exit_code, 0)
+
+        # testing for invalid text input for ceaser decryption
+        result = self.runner.invoke(yoda.cli, ["ciphers", "decrypt"],
+                                    input="0\n12345\n3")
+        self.assertNotEquals(result.exit_code, 0)
+
+        # testing for working ceaser encryption
+        result = self.runner.invoke(yoda.cli, ["ciphers", "encrypt"],
+                                    input="0\nsample\n3")
+        self.assertEqual(result.exit_code, 0)
+
+        # testing for working ceaser decryption
+        result = self.runner.invoke(yoda.cli, ["ciphers", "decrypt"],
+                                    input="0\nsample\n3")
+        self.assertEqual(result.exit_code, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ciphers/test_ceaser.py
+++ b/tests/ciphers/test_ceaser.py
@@ -12,7 +12,7 @@ class TestCeaser(unittest.TestCase):
         | Module: ciphers
         | command: ciphers
         | args: encrypt
-        | input: 0 <text> <shift>
+        | input: 1 <text> <shift>
     """
 
     def __init__(self, methodName="runTest"):
@@ -22,32 +22,32 @@ class TestCeaser(unittest.TestCase):
     def runTest(self):
         # testing for invalid shift input for ceaser encryption
         result = self.runner.invoke(yoda.cli, ["ciphers", "encrypt"],
-                                    input="0\nsample\na")
+                                    input="1\nsample\na")
         self.assertNotEqual(result.exit_code, 0)
 
         # testing for invalid shift input for ceaser decryption
         result = self.runner.invoke(yoda.cli, ["ciphers", "decrypt"],
-                                    input="0\nsample\na")
+                                    input="1\nsample\na")
         self.assertNotEqual(result.exit_code, 0)
 
         # testing for invalid text input for ceaser encryption
         result = self.runner.invoke(yoda.cli, ["ciphers", "encrypt"],
-                                    input="0\n$#$#\n3")
+                                    input="1\n$#$#\n3")
         self.assertNotEqual(result.exit_code, 0)
 
         # testing for invalid text input for ceaser decryption
         result = self.runner.invoke(yoda.cli, ["ciphers", "decrypt"],
-                                    input="0\n12345\n3")
+                                    input="1\n12345\n3")
         self.assertNotEqual(result.exit_code, 0)
 
         # testing for working ceaser encryption
         result = self.runner.invoke(yoda.cli, ["ciphers", "encrypt"],
-                                    input="0\nsample\n3")
+                                    input="1\nsample\n3")
         self.assertEqual(result.exit_code, 0)
 
         # testing for working ceaser decryption
         result = self.runner.invoke(yoda.cli, ["ciphers", "decrypt"],
-                                    input="0\nsample\n3")
+                                    input="1\nsample\n3")
         self.assertEqual(result.exit_code, 0)
 
 

--- a/tests/ciphers/test_ceaser.py
+++ b/tests/ciphers/test_ceaser.py
@@ -23,22 +23,22 @@ class TestCeaser(unittest.TestCase):
         # testing for invalid shift input for ceaser encryption
         result = self.runner.invoke(yoda.cli, ["ciphers", "encrypt"],
                                     input="0\nsample\na")
-        self.assertNotEquals(result.exit_code, 0)
+        self.assertNotEqual(result.exit_code, 0)
 
         # testing for invalid shift input for ceaser decryption
         result = self.runner.invoke(yoda.cli, ["ciphers", "decrypt"],
                                     input="0\nsample\na")
-        self.assertNotEquals(result.exit_code, 0)
+        self.assertNotEqual(result.exit_code, 0)
 
         # testing for invalid text input for ceaser encryption
         result = self.runner.invoke(yoda.cli, ["ciphers", "encrypt"],
                                     input="0\n$#$#\n3")
-        self.assertNotEquals(result.exit_code, 0)
+        self.assertNotEqual(result.exit_code, 0)
 
         # testing for invalid text input for ceaser decryption
         result = self.runner.invoke(yoda.cli, ["ciphers", "decrypt"],
                                     input="0\n12345\n3")
-        self.assertNotEquals(result.exit_code, 0)
+        self.assertNotEqual(result.exit_code, 0)
 
         # testing for working ceaser encryption
         result = self.runner.invoke(yoda.cli, ["ciphers", "encrypt"],

--- a/tests/ciphers/test_input.py
+++ b/tests/ciphers/test_input.py
@@ -1,0 +1,44 @@
+# coding=utf-8
+import unittest
+from click.testing import CliRunner
+
+import yoda
+
+
+class TestInput(unittest.TestCase):
+    """
+        Test for the following commands:
+
+        | Module: ciphers
+        | command: ciphers
+        | args: encrypt
+        | input: 0 <text> <shift>
+    """
+
+    def __init__(self, methodName="runTest"):
+        super(TestInput, self).__init__()
+        self.runner = CliRunner()
+
+    def runTest(self):
+        # testing for no mode passed for ciphers
+        result = self.runner.invoke(yoda.cli, ["ciphers"])
+        self.assertNotEquals(result.exit_code, 0)
+
+        # testing for invalid cipher input selection in encrypt mode
+        result = self.runner.invoke(yoda.cli, ["ciphers", "encrypt"],
+                                    input="3\nsample\na")
+        self.assertNotEquals(result.exit_code, 0)
+
+        # testing for invalid cipher input selection in decrypt mode
+        result = self.runner.invoke(yoda.cli, ["ciphers", "decrypt"],
+                                    input="3\nsample\na")
+        self.assertNotEquals(result.exit_code, 0)
+
+        # testing for invalid cipher mode
+        result = self.runner.invoke(yoda.cli, ["ciphers", "abc"],
+                                    input="3\nsample\na")
+        self.assertNotEquals(result.exit_code, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ciphers/test_input.py
+++ b/tests/ciphers/test_input.py
@@ -22,22 +22,22 @@ class TestInput(unittest.TestCase):
     def runTest(self):
         # testing for no mode passed for ciphers
         result = self.runner.invoke(yoda.cli, ["ciphers"])
-        self.assertNotEquals(result.exit_code, 0)
+        self.assertNotEqual(result.exit_code, 0)
 
         # testing for invalid cipher input selection in encrypt mode
         result = self.runner.invoke(yoda.cli, ["ciphers", "encrypt"],
                                     input="3\nsample\na")
-        self.assertNotEquals(result.exit_code, 0)
+        self.assertNotEqual(result.exit_code, 0)
 
         # testing for invalid cipher input selection in decrypt mode
         result = self.runner.invoke(yoda.cli, ["ciphers", "decrypt"],
                                     input="3\nsample\na")
-        self.assertNotEquals(result.exit_code, 0)
+        self.assertNotEqual(result.exit_code, 0)
 
         # testing for invalid cipher mode
         result = self.runner.invoke(yoda.cli, ["ciphers", "abc"],
                                     input="3\nsample\na")
-        self.assertNotEquals(result.exit_code, 0)
+        self.assertNotEqual(result.exit_code, 0)
 
 
 if __name__ == "__main__":

--- a/tests/ciphers/test_rot13.py
+++ b/tests/ciphers/test_rot13.py
@@ -22,13 +22,13 @@ class TestRot13(unittest.TestCase):
     def runTest(self):
         # testing for invalid text input for rot13 encryption
         result = self.runner.invoke(yoda.cli, ["ciphers", "encrypt"],
-                                    input="1\n$#$#")
-        self.assertNotEquals(result.exit_code, 0)
+                                    input="1\nabc1!")
+        self.assertNotEqual(result.exit_code, 0)
 
         # testing for invalid text input for rot13 decryption
         result = self.runner.invoke(yoda.cli, ["ciphers", "decrypt"],
                                     input="1\n12345")
-        self.assertNotEquals(result.exit_code, 0)
+        self.assertNotEqual(result.exit_code, 0)
 
         # testing for working rot13 encryption
         result = self.runner.invoke(yoda.cli, ["ciphers", "encrypt"],

--- a/tests/ciphers/test_rot13.py
+++ b/tests/ciphers/test_rot13.py
@@ -12,7 +12,7 @@ class TestRot13(unittest.TestCase):
         | Module: ciphers
         | command: ciphers
         | args: encrypt
-        | input: 1 <text>
+        | input: 2 <text>
     """
 
     def __init__(self, methodName="runTest"):
@@ -22,22 +22,22 @@ class TestRot13(unittest.TestCase):
     def runTest(self):
         # testing for invalid text input for rot13 encryption
         result = self.runner.invoke(yoda.cli, ["ciphers", "encrypt"],
-                                    input="1\nabc1!")
+                                    input="2\nabc1!")
         self.assertNotEqual(result.exit_code, 0)
 
         # testing for invalid text input for rot13 decryption
         result = self.runner.invoke(yoda.cli, ["ciphers", "decrypt"],
-                                    input="1\n12345")
+                                    input="2\n12345")
         self.assertNotEqual(result.exit_code, 0)
 
         # testing for working rot13 encryption
         result = self.runner.invoke(yoda.cli, ["ciphers", "encrypt"],
-                                    input="1\nsample")
+                                    input="2\nsample")
         self.assertEqual(result.exit_code, 0)
 
         # testing for working rot13 decryption
         result = self.runner.invoke(yoda.cli, ["ciphers", "decrypt"],
-                                    input="1\nsample")
+                                    input="2\nsample")
         self.assertEqual(result.exit_code, 0)
 
 

--- a/tests/ciphers/test_rot13.py
+++ b/tests/ciphers/test_rot13.py
@@ -1,0 +1,45 @@
+# coding=utf-8
+import unittest
+from click.testing import CliRunner
+
+import yoda
+
+
+class TestRot13(unittest.TestCase):
+    """
+        Test for the following commands:
+
+        | Module: ciphers
+        | command: ciphers
+        | args: encrypt
+        | input: 1 <text>
+    """
+
+    def __init__(self, methodName="runTest"):
+        super(TestRot13, self).__init__()
+        self.runner = CliRunner()
+
+    def runTest(self):
+        # testing for invalid text input for rot13 encryption
+        result = self.runner.invoke(yoda.cli, ["ciphers", "encrypt"],
+                                    input="1\n$#$#")
+        self.assertNotEquals(result.exit_code, 0)
+
+        # testing for invalid text input for rot13 decryption
+        result = self.runner.invoke(yoda.cli, ["ciphers", "decrypt"],
+                                    input="1\n12345")
+        self.assertNotEquals(result.exit_code, 0)
+
+        # testing for working rot13 encryption
+        result = self.runner.invoke(yoda.cli, ["ciphers", "encrypt"],
+                                    input="1\nsample")
+        self.assertEqual(result.exit_code, 0)
+
+        # testing for working rot13 decryption
+        result = self.runner.invoke(yoda.cli, ["ciphers", "decrypt"],
+                                    input="1\nsample")
+        self.assertEqual(result.exit_code, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
#### Short description of what this resolves:
Minor tweaks to how yoda exits during invalid inputs for ciphers module. 
adds tests for ciphers module.
#### Changes proposed in this pull request:

- Exit with status != 0 during invalid inputs 
- Tests to ciphers module [ ceaser, atbash and rot13 ]

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality