### PR TITLE
Mock external services in tests

### DIFF
--- a/modules/dev.py
+++ b/modules/dev.py
@@ -804,36 +804,37 @@ def run(ctx, path):
         Compile and run code without a local compiler.
     """
     if os.path.isfile(path):
-        source = open(path, "r").read()
-        file_extension = path.rsplit(".", 1)[1]
+        with open(path, "r") as source_file:
+            source = source_file.read()
+            file_extension = path.rsplit(".", 1)[1]
 
-        if file_extension not in supported_languages.keys():
-            click.echo(chalk.red("Sorry, Unsupported language."))
-            sys.exit(-1)
+            if file_extension not in supported_languages.keys():
+                click.echo(chalk.red("Sorry, Unsupported language."))
+                sys.exit(-1)
 
-        lang = supported_languages[file_extension]
-        compressed = 1
-        html = 0
-        params = RunAPIParameters(
-            client_secret=HACKEREARTH_API_KEY,
-            source=source,
-            lang=lang,
-            compressed=compressed,
-            html=html,
-        )
+            lang = supported_languages[file_extension]
+            compressed = 1
+            html = 0
+            params = RunAPIParameters(
+                client_secret=HACKEREARTH_API_KEY,
+                source=source,
+                lang=lang,
+                compressed=compressed,
+                html=html,
+            )
 
-        api = HackerEarthAPI(params)
+            api = HackerEarthAPI(params)
 
-        click.echo(chalk.yellow("Compiling code.."))
-        r = api.compile()
+            click.echo(chalk.yellow("Compiling code.."))
+            r = api.compile()
 
-        click.echo(chalk.cyan("Running code..."))
-        r = api.run()
-        output = r.__dict__.get("output")
+            click.echo(chalk.cyan("Running code..."))
+            r = api.run()
+            output = r.__dict__.get("output")
 
-        click.echo(chalk.green("Output:"))
-        click.echo(output)
-        click.echo("Link: " + r.__dict__.get("web_link"))
+            click.echo(chalk.green("Output:"))
+            click.echo(output)
+            click.echo("Link: " + r.__dict__.get("web_link"))
 
     else:
         click.echo(

--- a/tests/dev/test_fileshare.py
+++ b/tests/dev/test_fileshare.py
@@ -6,6 +6,12 @@ from click.testing import CliRunner
 import yoda
 
 
+FILE_UPLOAD_JSON_RESPONSE = {
+    u'link': u'https://file.io/unebeu', u'key': u'unebeu', u'success': True,
+    u'expiry': u'14 days'
+}
+
+
 class testFileshare(TestCase):
     """
         Test for the following commands:
@@ -22,7 +28,10 @@ class testFileshare(TestCase):
     def runTest(self):
         empty_response_json = {}
 
-        def test_with_correct_file_path():
+        @mock.patch('modules.dev.json')
+        @mock.patch('modules.dev.requests')
+        def test_with_correct_file_path(request, json):
+            json.loads.return_value = FILE_UPLOAD_JSON_RESPONSE
             result = self.runner.invoke(yoda.cli, ['fileshare', 'logo.png'])
             self.assertEqual(result.exit_code, 0)
 
@@ -30,12 +39,12 @@ class testFileshare(TestCase):
             result = self.runner.invoke(yoda.cli, ['fileshare', 'wrong_path'])
             self.assertEqual(result.exit_code, -1)
 
+        @mock.patch('modules.dev.requests')
         @mock.patch('json.loads', return_value=empty_response_json)
-        def test_with_no_key_in_response(_self):
+        def test_with_no_key_in_response(_self, requests):
             result = self.runner.invoke(yoda.cli, ['fileshare', 'logo.png'])
             self.assertEqual(result.exit_code, 1)
 
         test_with_correct_file_path()
         test_with_wrong_file_path()
         test_with_no_key_in_response()
-        

--- a/tests/dev/test_horoscope.py
+++ b/tests/dev/test_horoscope.py
@@ -7,8 +7,20 @@ from click.testing import CliRunner
 import yoda
 from requests.exceptions import ConnectionError
 
+
+ARIES_HOROSCOPE_RESULT = {
+    u'date': u'2019-03-21', u'sunsign': u'aries',
+    u'horoscope': (u'A plain Jane day. Work goes on as usual, and there is'
+                   u'progress. But as Ganesha says, it\'s an ordinary day. Hum,'
+                   u' whistle, doodle, and sip your green tea. While day '
+                   u'dreaming, start planning your dream home. After all, '
+                   u'that\'s where the first plan takes shape.')
+}
+
+
 def function_with_connection_error():
     raise ConnectionError()
+
 
 class TestHoroscope(TestCase):
     """
@@ -24,7 +36,9 @@ class TestHoroscope(TestCase):
 
     def runTest(self):
 
-        def test_with_correct_input():
+        @mock.patch('modules.dev.requests')
+        def test_with_correct_input(requests):
+            requests.get.json.return_value = ARIES_HOROSCOPE_RESULT
             result = self.runner.invoke(yoda.cli, ['horoscope', 'aries'])
             if sys.version_info[0] == 3:
                 string_types = str

--- a/tests/dev/test_run.py
+++ b/tests/dev/test_run.py
@@ -1,5 +1,7 @@
 # coding=utf-8
+from mock import patch, Mock
 from unittest import TestCase
+
 from click.testing import CliRunner
 
 import yoda
@@ -17,21 +19,39 @@ class TestRun(TestCase):
         super(TestRun, self).__init__()
         self.runner = CliRunner()
 
-    def runTest(self):
+    @patch('modules.dev.HackerEarthAPI')
+    @patch('modules.dev.RunAPIParameters')
+    def runTest(self, RunAPIParameters, HackerEarthAPI):
+        mock_api_run_result = Mock()
+        mock_api_run_result.__dict__['output'] = 'output'
+        mock_api_run_result.__dict__['web_link'] = 'web_link'
+        HackerEarthAPI().run.return_value = mock_api_run_result
+
+        # Testing with existing file
         result = self.runner.invoke(yoda.cli, ["run", "tests/resources/test_code.py"])
         self.assertEqual(result.exit_code, 0)
         output_string = str(
             result.output.encode("ascii", "ignore").decode("utf-8")
         ).strip()
+        expected_result = ('Compiling code..\nRunning code...\n'
+                           'Output:\noutput\nLink: web_link')
+        self.assertIn(output_string, expected_result)
 
+        # Testing missing file
         result = self.runner.invoke(yoda.cli, ["run", "no_file.py"])
         self.assertEqual(result.exit_code, 1)
         output_string = str(
             result.output.encode("ascii", "ignore").decode("utf-8")
         ).strip()
+        expected_result = ('No file such as no_file.py, '
+                           'Please re-check the file path and try again.')
+        self.assertIn(output_string, expected_result)
 
+        # Testing unsupported language
         result = self.runner.invoke(yoda.cli, ["run", "logo.png"])
         self.assertEqual(result.exit_code, -1)
         output_string = str(
             result.output.encode("ascii", "ignore").decode("utf-8")
         ).strip()
+        expected_result = 'Sorry, Unsupported language.'
+        self.assertIn(output_string, expected_result)

--- a/tests/dev/test_speedtest.py
+++ b/tests/dev/test_speedtest.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+from mock import patch
 from unittest import TestCase
 from click.testing import CliRunner
 
@@ -13,15 +14,13 @@ class TestSpeedtest(TestCase):
         | command: speedtest
     """
 
-    def __init__(self, methodName="runTest"):
+    def __init__(self, methodName='runTest'):
         super(TestSpeedtest, self).__init__()
         self.runner = CliRunner()
 
-    def runTest(self):
-        result = self.runner.invoke(yoda.cli, ["speedtest"])
-        print(
-            "------============------============------============------============------============------============------============"
-        )
-        print(str(result.output.encode("ascii", "ignore")))
+    @patch('modules.dev.os')
+    def runTest(self, os):
+        result = self.runner.invoke(yoda.cli, ['speedtest'])
+        os.system.assert_called_once_with('speedtest-cli')
         self.assertEqual(result.exit_code, 0)
         self.assertIsNone(result.exception)

--- a/tests/dev/test_url.py
+++ b/tests/dev/test_url.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from builtins import str
+from mock import patch, MagicMock
 from unittest import TestCase
 from click.testing import CliRunner
 
@@ -13,37 +14,53 @@ class TestSpeedtest(TestCase):
         | Module: dev
         | command: url
     """
+    URL_SHORTEN_RESPONSE = {
+        u'previewLink': u'https://yodacli.page.link/w7zEiUimwB1nMqwRA?d=1',
+        u'warning': [
+            {u'warningCode': u'UNRECOGNIZED_PARAM',
+             u'warningMessage': u"iOS app 'com.yodacli' lacks App ID Prefix.]"},
+        ],
+        u'shortLink': u'https://yodacli.page.link/RpXwYjkpLr5cT5Kd9'
+    }
+    URL_EXPAND_RESPONSE = {
+        u'status': u'OK', u'kind': u'urlshortener#url',
+        u'id': u'https://yodacli.page.link/RpXwYjkpLr5cT5Kd9',
+        u'longUrl': u'https://yodacli.page.link/?link=http://manparvesh.com/'
+    }
 
     def __init__(self, methodName="runTest"):
         super(TestSpeedtest, self).__init__()
         self.runner = CliRunner()
 
     def runTest(self):
-        # shorten url
-        url_to_test = "http://manparvesh.com/".strip()
-        result = self.runner.invoke(yoda.cli, ["url", "shorten", url_to_test])
-        self.assertEqual(result.exit_code, 0)
-        output_string = str(result.output.encode("ascii", "ignore").decode("utf-8"))
+        with patch('modules.dev.requests') as requests:
+            # shorten url
+            url_to_test = "http://manparvesh.com/".strip()
+            requests.post().json.return_value = self.URL_SHORTEN_RESPONSE
+            result = self.runner.invoke(yoda.cli, ["url", "shorten", url_to_test])
+            self.assertEqual(result.exit_code, 0)
+            output_string = str(result.output.encode("ascii", "ignore").decode("utf-8"))
+            self.assertEqual(type(output_string), str)
+            self.assertTrue(output_string.startswith("Here's your shortened URL:"))
+            shortened_url = str(output_string[str(output_string).find("http"):]).strip()
 
-        self.assertEqual(type(output_string), str)
-        self.assertTrue(output_string.startswith("Here's your shortened URL:"))
-        shortened_url = str(output_string[str(output_string).find("http") :]).strip()
+        with patch('modules.dev.requests') as requests:
+            requests.get().json.return_value = self.URL_EXPAND_RESPONSE
+            # expand url
+            result_decode = self.runner.invoke(yoda.cli, ["url", "expand", shortened_url])
+            self.assertEqual(result_decode.exit_code, 0)
+            second_output_string = str(
+                result_decode.output.encode("ascii", "ignore").decode("utf-8")
+            )
 
-        # expand url
-        result_decode = self.runner.invoke(yoda.cli, ["url", "expand", shortened_url])
-        self.assertEqual(result_decode.exit_code, 0)
-        second_output_string = str(
-            result_decode.output.encode("ascii", "ignore").decode("utf-8")
-        )
+            self.assertEqual(type(second_output_string), str)
+            self.assertTrue(second_output_string.startswith("Here's your original URL:"))
+            expanded_url = str(
+                second_output_string[str(second_output_string).find("http"):]
+            ).strip()
 
-        self.assertEqual(type(second_output_string), str)
-        self.assertTrue(second_output_string.startswith("Here's your original URL:"))
-        expanded_url = str(
-            second_output_string[str(second_output_string).find("http") :]
-        ).strip()
-
-        # check if the original url and obtained url are equal
-        self.assertEqual(url_to_test, expanded_url)
+            # check if the original url and obtained url are equal
+            self.assertEqual(url_to_test, expanded_url)
 
         # incorrect command should show our custom response instead of stacktrace
         result = self.runner.invoke(yoda.cli, ["url", "incorrect_subcommand", "aaa"])

--- a/tests/dev/test_whois.py
+++ b/tests/dev/test_whois.py
@@ -1,7 +1,31 @@
+from mock import patch, PropertyMock
 import unittest
 
 from click.testing import CliRunner
 import yoda
+
+
+GOOGLE_WHOIS = (
+    u'<!DOCTYPE HTML><html dir="ltr"><body class="home-bg"> Domain Information'
+    u'</div><div class="df-label">Domain:</div><div class="df-value">google.com'
+    u'</div></div><div class="df-label">Registrar:</div><div class="df-value"'
+    u'>MarkMonitor Inc.</div><div class="df-label">Registered On:</div><div '
+    u'class="df-value">1997-09-15</div><div class="df-label">Expires On:</div>'
+    u'<div class="df-value">2020-09-13 </div><div class="df-label">Updated On:'
+    u'</div><div class="df-value">2018-02-21</div> <div class="df-label">'
+    u'Status:</div><div class="df-value">clientDeleteProhibited</div><div class'
+    u'="df-label">Name Servers:</div><div class="df-value">ns1.google.com</div>'
+    u'<div class="df-label">Organization:</div><div class="df-value">Google LLC'
+    u'</div><div class="df-label">State:</div><div class=class="df-label">State'
+    u':</div><div class="df-value">CA</div><div class="df-label">Country:</div>'
+    u'<div class="df-value">US</div></div></div><div class="df-label"> '
+    u'Organization:</div><div class="df-value">Google LLC</div><div class='
+    u'"df-label">State:</div><div class="df-value">CA</div><div class="df-label'
+    u'">Country:</div><div class="df-value">US</div<div class="df-label">'
+    u'Organization:</div><div class="df-value">Google LLC</div><div class='
+    u'"df-label">State:</div><div class="df-value">CA</div><div class="df-label'
+    u'">Country:</div><div class="df-value">US</div></div></body></html>'
+)
 
 
 class TestWhois(unittest.TestCase):
@@ -17,16 +41,29 @@ class TestWhois(unittest.TestCase):
         self.runner = CliRunner()
 
     def runTest(self):
-        result = self.runner.invoke(yoda.cli, ["whois", "https://google.com"])
-        self.assertEqual(result.exit_code, 0)
-        output_string = str(
-            result.output.encode("ascii", "ignore").decode("utf-8")
-        ).strip()
+        with patch('modules.dev.requests') as requests:
+            text_return_value = PropertyMock(return_value=GOOGLE_WHOIS)
+            type(requests.get.return_value).text = text_return_value
+            result = self.runner.invoke(
+                yoda.cli, ["whois", "https://google.com"]
+            )
+            self.assertEqual(result.exit_code, 0)
+            output_string = str(
+                result.output.encode("ascii", "ignore").decode("utf-8")
+            ).strip()
+            self.assertIn('google.com', output_string)
+            self.assertIn('Google LLC', output_string)
 
-        result = self.runner.invoke(
-            yoda.cli, ["whois", "http://asdfghjklpoiuytrew.com/"]
-        )
-        self.assertEqual(result.exit_code, 1)
-        output_string = str(
-            result.output.encode("ascii", "ignore").decode("utf-8")
-        ).strip()
+        with patch('modules.dev.requests') as requests:
+            text_return_value = PropertyMock(return_value='')
+            type(requests.get.return_value).text = text_return_value
+            result = self.runner.invoke(
+                yoda.cli, ["whois", "http://asdfghjklpoiuytrew.com/"]
+            )
+            self.assertEqual(result.exit_code, 1)
+            output_string = str(
+                result.output.encode("ascii", "ignore").decode("utf-8")
+            ).strip()
+            self.assertIn(
+                'This domain has not been registered yet :/', output_string
+            )

--- a/tests/entertainment/test_lyrics.py
+++ b/tests/entertainment/test_lyrics.py
@@ -1,8 +1,17 @@
 # coding=utf-8
+from mock import patch
 import unittest
 from click.testing import CliRunner
 
 import yoda
+
+COLDPLAY_LYRICS = {
+    'lyrics': ('Turn your magic on\nUmi she\'d say\nEverything you want\'s a'
+               'dream away\nAnd we are legends every day\nThat\'s what she told'
+               'me\n\nTurn your magic on\nTo me she\'d say\nEverything you '
+               'want\'s a dream away\nUnder this pressure, under this weight..')
+}
+NO_LYRICS_FOUND = {'error': 'No lyrics found'}
 
 
 class TestLyrics(unittest.TestCase):
@@ -18,10 +27,24 @@ class TestLyrics(unittest.TestCase):
         self.runner = CliRunner()
 
     def runTest(self):
-        result = self.runner.invoke(
-            yoda.cli, ["lyrics"], input="Coldplay\nAdventure of a Lifetime"
-        )
-        self.assertEqual(result.exit_code, 0)
+        with patch('modules.entertainment.requests') as requests:
+            requests.get().json.return_value = COLDPLAY_LYRICS
+            result = self.runner.invoke(
+                yoda.cli, ['lyrics'], input='Coldplay\nAdventure of a Lifetime'
+            )
+            output_string = str(
+                result.output.encode("ascii", "ignore").decode("utf-8")
+            ).strip()
+            self.assertIn('--------Lyrics--------', output_string)
+            self.assertEqual(result.exit_code, 0)
 
-        result = self.runner.invoke(yoda.cli, ["lyrics"], input="None\nNone")
-        self.assertEqual(result.exit_code, 0)
+        with patch('modules.entertainment.requests') as requests:
+            requests.get().json.return_value = NO_LYRICS_FOUND
+            result = self.runner.invoke(
+                yoda.cli, ['lyrics'], input='None\nNone'
+            )
+            output_string = str(
+                result.output.encode("ascii", "ignore").decode("utf-8")
+            ).strip()
+            self.assertIn('No lyrics found', output_string)
+            self.assertEqual(result.exit_code, 0)

--- a/tests/food/test_suggest_drinks.py
+++ b/tests/food/test_suggest_drinks.py
@@ -1,3 +1,4 @@
+from mock import patch
 import unittest
 import yoda
 from click.testing import CliRunner
@@ -10,12 +11,26 @@ class TestSuggestDrink(unittest.TestCase):
         | Module: food
         | command: suggest_drinks
     """
+    RANDOM_DRINK = {
+        'drinks': [{
+            'strDrink': 'Oatmeal Cookie',
+            'strInstructions': 'Just mix it all together.',
+            'strIngredient1': 'Kahlua', 'strIngredient2': 'Bailey',
+            'strIngredient3': 'Butterscotch schnapps',
+            'strIngredient4': 'Jagermeister', 'strIngredient5': 'Goldschlager',
+            'strMeasure1': '2 parts', 'strMeasure2': '2 parts',
+            'strMeasure3': '4 parts', 'strMeasure4': '1 part',
+            'strMeasure5': '1/2 part'
+        }]
+    }
 
     def __init__(self, methodName="runTest"):
         super(TestSuggestDrink, self).__init__()
         self.runner = CliRunner()
 
-    def runTest(self):
+    @patch('modules.food.requests')
+    def runTest(self, requests):
+        requests.get.json.return_value = self.RANDOM_DRINK
         # Test Drink Suggestion
         result = self.runner.invoke(yoda.cli, ["food", "suggest_drinks"])
         self.assertIsNone(result.exception)

--- a/tests/learn/test_dictionary.py
+++ b/tests/learn/test_dictionary.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from builtins import str
+from mock import patch
 from unittest import TestCase
 from click.testing import CliRunner
 
@@ -13,12 +14,36 @@ class TestDictionary(TestCase):
         | Module: learn
         | command: define, synonym, antonym, example
     """
+    DICTIONARY_RESPONSE = {
+        u'word': u'fat',
+        u'definitions': [
+            {u'definition': u'make fat or plump', u'partOfSpeech': u'verb'},
+            {u'definition': u'lucrative', u'partOfSpeech': u'adjective'},
+            {u'definition': u'marked by great fruitfulness',
+                            u'partOfSpeech': u'adjective'},
+            {u'definition': u'excess bodily weight', u'partOfSpeech': u'noun'},
+        ],
+        u'synonyms': [
+            u'fatten', u'fatten out', u'fatten up', u'fill out', u'flesh out',
+            u'plump', u'plump out', u'juicy', u'fertile', u'productive',
+            u'rich', u'avoirdupois', u'blubber', u'fatness', u'adipose tissue',
+            u'fatty tissue', u'fatty'],
+        u'antonyms': [u'thin'],
+        u'examples': [
+            u'a nice fat job', u'a fat land', u'fatty food', u'fat tissue',
+            u'she disliked fatness in herself as well as in others',
+            u'fatty tissue protected them from the severe cold', u'a fat rope'
+            u'pizza has too much fat', u'he hadn\'t remembered how fat she was'
+        ]
+    }
 
     def __init__(self, methodName="runTest"):
         super(TestDictionary, self).__init__()
         self.runner = CliRunner()
 
-    def runTest(self):
+    @patch('modules.learn.requests')
+    def runTest(self, requests):
+        requests.get.json.return_value = self.DICTIONARY_RESPONSE
         result = self.runner.invoke(yoda.cli, ["dictionary", "define", "fat"])
         self.assertEqual(result.exit_code, 0)
         output_string = str(result.output.encode("ascii", "ignore"))

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1,8 +1,20 @@
 # coding=utf-8
+from mock import patch, MagicMock
 from unittest import TestCase
 from click.testing import CliRunner
 
 import yoda
+
+HELLO_JSON_RESPONSE = (
+    '{"id": "55e0f6b9-be28-4314-9b44-4b55702029fa", '
+    '"timestamp": "2019-04-05T11:56:33.632Z", "lang": "en", "result": '
+    '{"source": "domains","resolvedQuery": "hello ", "action":'
+    '"smalltalk.greetings.hello","actionIncomplete": false, "parameters": {},'
+    '"contexts": [],"metadata": {},"fulfillment": {"speech":'
+    '"Good day!", "messages": [{"type": 0,  "speech": "Hey there!"}]},'
+    '"score": 1.0}, "status": {"code": 200,"errorType":"success"}, '
+    '"sessionId": "dd60fde7-c6ab-4f38-9487-7300c42b4916"}'
+)
 
 
 class TestChat(TestCase):
@@ -18,8 +30,10 @@ class TestChat(TestCase):
         self.runner = CliRunner()
 
     def runTest(self):
-        result = self.runner.invoke(yoda.cli, ["chat", "hello"])
-        self.assertEqual(result.exit_code, 0)
+        with patch('modules.chat.request') as request:
+            request.getresponse().read = MagicMock(return_value=HELLO_JSON_RESPONSE)
+            result = self.runner.invoke(yoda.cli, ["chat", "hello"])
+            self.assertEqual(result.exit_code, 0)
 
         result = self.runner.invoke(yoda.cli, ["chat"])
         self.assertEqual(result.exit_code, 0)

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -31,7 +31,7 @@ class TestChat(TestCase):
 
     def runTest(self):
         with patch('modules.chat.request') as request:
-            request.getresponse().read = MagicMock(return_value=HELLO_JSON_RESPONSE)
+            request.getresponse().read = MagicMock(return_value=HELLO_JSON_RESPONSE.encode('utf-8'))
             result = self.runner.invoke(yoda.cli, ["chat", "hello"])
             self.assertEqual(result.exit_code, 0)
 

--- a/tests/test_money.py
+++ b/tests/test_money.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+from mock import patch
 from unittest import TestCase
 from click.testing import CliRunner
 
@@ -17,7 +18,15 @@ class TestHealth(TestCase):
         super(TestHealth, self).__init__()
         self.runner = CliRunner()
 
-    def runTest(self):
+    @patch('modules.money.convert')
+    @patch('modules.money.currency_codes')
+    @patch('modules.money.currency_rates.get_rates')
+    def runTest(self, get_rates, currency_codes, convert):
+        currency_codes.get_symbol.return_value = 'USD'
+        get_rates.return_value = {'USD': 1}
+        convert.return_value = 1
+        currency_codes.get_currency_name.return_value = 'USD'
+
         result = self.runner.invoke(yoda.cli, ["money", "status"])
         self.assertEqual(result.exit_code, 0)
 

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -1,7 +1,7 @@
 # coding=utf-8
+import mock
 import unittest
 from click.testing import CliRunner
-
 import yoda
 
 
@@ -9,32 +9,21 @@ class TestWeather(unittest.TestCase):
     """
         Test for the following commands:
 
-        | Module: weather 
-        | command: weather 
+        | Module: weather
+        | command: weather
     """
 
     def __init__(self, methodName="runTest"):
         super(TestWeather, self).__init__()
         self.runner = CliRunner()
 
-    def runTest(self):
-        # testing for working weather service call
-        result = self.runner.invoke(yoda.cli, ["weather", "new york"])
+    @mock.patch('modules.weather.get_weather')
+    def runTest(self, get_weather):
+        city = "new york"
+        expected_call = "new york "
+        result = self.runner.invoke(yoda.cli, ["weather", city])
+        get_weather.assert_called_once_with(expected_call)
         self.assertEqual(result.exit_code, 0)
-
-        # testing that the correct info is pulled for the correct location
-
-        city = "Mexico City"
-        result = self.runner.invoke(yoda.cli, ["weather", city])
-        self.assertTrue("Mexico+City".lower() in result.output.lower())
-
-        city = "Tokyo"
-        result = self.runner.invoke(yoda.cli, ["weather", city])
-        self.assertTrue(city.lower() in result.output.lower())
-
-        city = "Belleville Ontario"
-        result = self.runner.invoke(yoda.cli, ["weather", city])
-        self.assertTrue("Belleville+Ontario".lower() in result.output.lower())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#### Short description of what this resolves:
Mock external services calls in tests.
#### Changes proposed in this pull request:
For external services, we should be mocking the services instead of using the actual URLs:

- External services are slow;
- They are unpredictable;

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the README with example

