### PR TITLE
moved pandas import to a function to improve load time

### DIFF
--- a/modules/chat.py
+++ b/modules/chat.py
@@ -13,21 +13,30 @@ except ImportError:
     # Fall back to Python 2's urllib2
     from urllib2 import urlopen, Request
 
-import apiai
 import chalk
 import click
 
 from . import config
 
 CLIENT_ACCESS_TOKEN = os.environ.get("API_AI_TOKEN", config.API_AI_TOKEN)
-ai = apiai.ApiAI(CLIENT_ACCESS_TOKEN)
-request = ai.text_request()
-request.session_id = os.environ.get("API_AI_SESSION_ID", config.API_AI_SESSION_ID)
+
 
 QUOTE_API_URL = "https://api.forismatic.com/api/1.0/"
 
+'''
+setup function for apiai import and related variables
+Putting these in a function improves load time for all yoda commands
+'''
+def import_apiai():
+    global apiai, request
+    import apiai
+
+    ai = apiai.ApiAI(CLIENT_ACCESS_TOKEN)
+    request = ai.text_request()
+    request.session_id = os.environ.get("API_AI_SESSION_ID", config.API_AI_SESSION_ID)
 
 def process(input_string):
+    import_apiai()
     """
     minimal chat bot
     :param input_string:

--- a/modules/chat.py
+++ b/modules/chat.py
@@ -23,6 +23,9 @@ CLIENT_ACCESS_TOKEN = os.environ.get("API_AI_TOKEN", config.API_AI_TOKEN)
 
 QUOTE_API_URL = "https://api.forismatic.com/api/1.0/"
 
+# required to be compatible with mocking tests
+request = None
+
 '''
 setup function for apiai import and related variables
 Putting these in a function improves load time for all yoda commands

--- a/modules/dev.py
+++ b/modules/dev.py
@@ -45,6 +45,10 @@ KEYBINDINGS_CONFIG_FOLDER_PATH = get_folder_path_from_file_path(
     KEYBINDINGS_CONFIG_FILE_PATH
 )
 
+'''
+setup function for importing pandas
+Putting this in a function improves load time for all yoda commands
+'''
 def import_pandas():
     global pd
     import pandas as pd

--- a/modules/dev.py
+++ b/modules/dev.py
@@ -11,14 +11,9 @@ import sys
 from builtins import range
 from builtins import str
 
-from pydub import AudioSegment
-from pydub.playback import play
-
-from fuzzywuzzy import fuzz
-
-import pyspeedtest
 import os
 import requests
+#final changes
 
 from past.utils import old_div
 
@@ -210,6 +205,11 @@ def search_keybindings(software, search_key):
     :param software:
     :param search_key:
     """
+
+    #importing fuzzywuzzy in this function improves load time for all yoda commands
+    from fuzzywuzzy import fuzz
+
+
     SOFTWARE_FILE_PATH = get_software_file_path(software)
     matched_keys = []
     matched_actions = []
@@ -506,6 +506,11 @@ def mp3cutter(ctx, path, start, end):
 
     yoda dev mp3cutter MUSIC_PATH START[default: 0] END[default:lenght of music]
     """
+
+    #importing pydub functions in this function improves load time for all yoda commands
+    from pydub import AudioSegment
+    from pydub.playback import play
+
     click.echo("\nOpening file...")
 
     if not os.path.isfile(path):
@@ -606,6 +611,9 @@ def whois(ctx, domain):
 
 
 def get_whois_data(domain):
+    #importing BeautifulSoup in this function improves load time for all yoda commands
+    from bs4 import BeautifulSoup
+
     req = requests.get(whois_base_url + domain)
     html = req.text
 

--- a/modules/dev.py
+++ b/modules/dev.py
@@ -19,7 +19,6 @@ from fuzzywuzzy import fuzz
 import pyspeedtest
 import os
 import requests
-import pandas as pd
 
 from past.utils import old_div
 
@@ -46,6 +45,9 @@ KEYBINDINGS_CONFIG_FOLDER_PATH = get_folder_path_from_file_path(
     KEYBINDINGS_CONFIG_FILE_PATH
 )
 
+def import_pandas():
+    global pd
+    import pandas as pd
 
 def get_software_file_path(software_name):
     """
@@ -158,6 +160,7 @@ def check_sub_command_url(action, url_to_be_expanded_or_shortened):
 
 
 def add_keybindings(software, keybinding_filepath):
+    import_pandas()
     """
     add/import key binding file
     :param software:
@@ -380,6 +383,7 @@ def portscan():
 @click.pass_context
 @click.argument("ip_address", nargs=1, required=False, callback=alias_checker)
 def iplookup(ctx, ip_address):
+    import_pandas()
     """
     Find the geographical location of a given IP address.
     """

--- a/modules/gif.py
+++ b/modules/gif.py
@@ -2,7 +2,6 @@ import os
 
 import chalk
 import click
-import imageio
 
 
 @click.group()
@@ -25,6 +24,9 @@ def gif():
 )
 @click.pass_context
 def from_images(ctx):
+    #importing imageio in theis function improves load time for all yoda commands
+    import imageio
+
     args = {
         ctx.args[i].strip("--"): ctx.args[i + 1] for i in range(0, len(ctx.args), 2)
     }

--- a/modules/money.py
+++ b/modules/money.py
@@ -29,6 +29,9 @@ MONEY_CONFIG_FOLDER_PATH = get_folder_path_from_file_path(MONEY_CONFIG_FILE_PATH
 currency_rates = CurrencyRates()
 currency_codes = CurrencyCodes()
 
+# required to be compatible with mocking tests
+request = None
+
 '''
 setup function for apiai import and related variables
 Putting these in a function improves load time for all yoda commands

--- a/modules/money.py
+++ b/modules/money.py
@@ -6,7 +6,7 @@ import json
 import shlex
 import time
 
-import apiai
+
 from forex_python.converter import (
     CurrencyRates,
     CurrencyCodes,
@@ -19,9 +19,7 @@ from .config import get_config_file_paths
 from .util import *
 
 CLIENT_ACCESS_TOKEN = os.environ.get("API_AI_TOKEN", config.API_AI_TOKEN)
-ai = apiai.ApiAI(CLIENT_ACCESS_TOKEN)
-request = ai.text_request()
-request.session_id = os.environ.get("API_AI_SESSION_ID", config.API_AI_SESSION_ID)
+
 
 # config file path
 MONEY_CONFIG_FILE_PATH = get_config_file_paths()["MONEY_CONFIG_FILE_PATH"]
@@ -30,6 +28,18 @@ MONEY_CONFIG_FOLDER_PATH = get_folder_path_from_file_path(MONEY_CONFIG_FILE_PATH
 # currency converter
 currency_rates = CurrencyRates()
 currency_codes = CurrencyCodes()
+
+'''
+setup function for apiai import and related variables
+Putting these in a function improves load time for all yoda commands
+'''
+def import_apiai():
+    global apiai, request
+    import apiai
+
+    ai = apiai.ApiAI(CLIENT_ACCESS_TOKEN)
+    request = ai.text_request()
+    request.session_id = os.environ.get("API_AI_SESSION_ID", config.API_AI_SESSION_ID)
 
 
 def __validate_currency_name_and_amount(currency_name, amount):
@@ -92,6 +102,7 @@ def setup():
 
 
 def expense():
+    import_apiai()
     """
     add expense
     """

--- a/modules/setup.py
+++ b/modules/setup.py
@@ -10,8 +10,6 @@ import string
 
 import chalk
 import click
-import lepl.apps.rfc3696
-import yaml
 from Crypto.Cipher import AES
 from builtins import input
 from builtins import range
@@ -90,6 +88,10 @@ def new():
     create new config file
     :return:
     """
+    #importing lepl in this function improves load time for all yoda commands
+    import lepl.apps.rfc3696
+
+
     click.echo(chalk.blue("Enter your name:"))
     name = input().strip()
     while len(name) == 0:

--- a/modules/setup.py
+++ b/modules/setup.py
@@ -10,6 +10,7 @@ import string
 
 import chalk
 import click
+import yaml
 from Crypto.Cipher import AES
 from builtins import input
 from builtins import range
@@ -88,9 +89,9 @@ def new():
     create new config file
     :return:
     """
+
     #importing lepl in this function improves load time for all yoda commands
     import lepl.apps.rfc3696
-
 
     click.echo(chalk.blue("Enter your name:"))
     name = input().strip()

--- a/modules/util.py
+++ b/modules/util.py
@@ -5,7 +5,6 @@ import os.path
 import subprocess
 
 import re
-from bs4 import BeautifulSoup
 
 import chalk
 import click


### PR DESCRIPTION
#### Short description of what this resolves:
Refactors the code in modules so that certain import statements and code will only run if a command is called, improving overall Yoda response time.

It seems that a lot of the slowdown is caused by specific import statements. It might be best to only move these specific statements, instead of all import functions and executing code, into setup functions in order to reduce the amount of refactoring needed.

#### Changes proposed in this pull request:
- Moved Pandas import call into a function
- added calls to aforementioned function in the commands which require Pandas
- This improved the average response time of the "Yoda" command from 1 second, to .8 seconds on my machine. Doing this to other import statements should decrease this time even further

I plan to analyze all the modules in Yoda to find other culprit imports implement these changes to them, but wanted to get feedback on this approach before investing too much time into it.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the README with example

**Fixes**: #241
